### PR TITLE
Add easier devsetup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ build.properties
 
 # H2
 camunda-h2-dbs
+*.iml

--- a/README.md
+++ b/README.md
@@ -16,10 +16,28 @@ This plugin provides a set of charts helping you to understand what is and what 
 
 ![Screenshot: Process Definition](screenshot-process-definition.png)
 
+
 ## Get started
 
 To include this plugin into your cockpit you can either include it in your custom build on [camunda's plugin store](http://camunda.org/plugins/) or you build the cockpit on your own and deploy it to your server.
 Do not forget to customize build.properties in case you choose the latter option.
+
+
+### Giving it a quick Try
+
+If you want to have a quick look at this project, you can start a running instance of camunda BPM cockpit in the following way:
+
+* Cone the project using git: `git clone https://github.com/camunda/camunda-cockpit-plugin-statistics.git`
+* Start the camunda Webapp from the commandline: 
+
+```bash
+cd camunda-cockpit-plugin-statistics
+mvn clean jetty:run -Pdevelop
+```
+* go to [http://localhost:8080/camunda](http://localhost:8080/camunda)
+* Login with `demo:demo`
+
+In Cockpit you will see a couple of plugins which display statistics about your process definitions and so on.
 
 
 ## Roadmap
@@ -48,6 +66,7 @@ Do not forget to customize build.properties in case you choose the latter option
 
 [Eric Klieme](https://github.com/eklieme) ([NovaTec Consulting GmbH](http://www.novatec-gmbh.de/))
 
+
 ## Contributors
 
 Within NovaTec Consulting GmbH the following persons are contributing
@@ -58,6 +77,7 @@ Within NovaTec Consulting GmbH the following persons are contributing
 
 
 ![NovaTec Consulting GmbH](http://www.novatec-gmbh.de/fileadmin/styles/novatec_v5.5/images/header-logo.jpg)
+
 
 ## License
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>camunda-cockpit-plugin-statistics-root</artifactId>
     <version>1.0.0</version>
     <name>Camunda Web App Statistics Plugin</name>
-    <description>NovaTec`s fancy statitstics plugin</description>
+    <description>NovaTec`s fancy statistics plugin</description>
 
     <packaging>jar</packaging>
 
@@ -165,4 +165,56 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>develop</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.camunda.bpm.webapp</groupId>
+                    <artifactId>camunda-webapp-tomcat-standalone</artifactId>
+                    <version>${camunda.version}</version>
+                    <type>war</type>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.mortbay.jetty</groupId>
+                        <artifactId>jetty-maven-plugin</artifactId>
+                        <version>8.1.14.v20131031</version>
+                        <configuration>
+                            <webAppConfig>
+                                <contextPath>/camunda</contextPath>
+                                <resourceBases>
+                                    <resourceBase>${project.basedir}/src/main/resources</resourceBase>
+                                    <resourceBAse>${project.basedir}/src/develop/resources</resourceBAse>
+                                </resourceBases>
+                            </webAppConfig>
+                          <jvmArgs>-Xmx2048m -Xms1536m -XX:PermSize=256m -XX:MaxPermSize=384m</jvmArgs>
+                        </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>1.9</version>
+                    <executions>
+                        <execution>
+                            <id>add-source</id>
+                            <phase>generate-sources</phase>
+                            <goals>
+                                <goal>add-source</goal>
+                            </goals>
+                            <configuration>
+                                <sources>
+                                   <source>src/develop/java</source>
+                                </sources>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+          </plugins>
+        </build>
+      </profile>
+    </profiles>
 </project>

--- a/src/develop/java/org/camunda/bpm/extension/elasticsearch/cockpit/demodata/DemoDataGenerator.java
+++ b/src/develop/java/org/camunda/bpm/extension/elasticsearch/cockpit/demodata/DemoDataGenerator.java
@@ -1,0 +1,123 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.extension.elasticsearch.cockpit.demodata;
+
+import static org.camunda.bpm.engine.authorization.Authorization.ANY;
+import static org.camunda.bpm.engine.authorization.Authorization.AUTH_TYPE_GRANT;
+import static org.camunda.bpm.engine.authorization.Permissions.ALL;
+
+import java.util.List;
+import java.util.Random;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import org.camunda.bpm.engine.AuthorizationService;
+import org.camunda.bpm.engine.IdentityService;
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.authorization.Groups;
+import org.camunda.bpm.engine.authorization.Resource;
+import org.camunda.bpm.engine.authorization.Resources;
+import org.camunda.bpm.engine.identity.Group;
+import org.camunda.bpm.engine.identity.User;
+import org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity;
+import org.camunda.bpm.engine.task.Task;
+import org.springframework.beans.factory.InitializingBean;
+
+/**
+ * @author Daniel Meyer
+ *
+ */
+public class DemoDataGenerator implements InitializingBean {
+
+  private static final int maxInstances = 10;
+
+  protected ProcessEngine processEngine;
+
+  public void afterPropertiesSet() throws Exception {
+
+    System.out.println("Generating demo data");
+
+    scheduleInstanceStart();
+
+    // ensure admin user exists
+    IdentityService identityService = processEngine.getIdentityService();
+    User user = identityService.createUserQuery().userId("demo").singleResult();
+    if(user == null) {
+      User newUser = identityService.newUser("demo");
+      newUser.setPassword("demo");
+      identityService.saveUser(newUser);
+      System.out.println("Created used 'demo', password 'demo'");
+      AuthorizationService authorizationService = processEngine.getAuthorizationService();
+
+      // create group
+      if(identityService.createGroupQuery().groupId(Groups.CAMUNDA_ADMIN).count() == 0) {
+        Group camundaAdminGroup = identityService.newGroup(Groups.CAMUNDA_ADMIN);
+        camundaAdminGroup.setName("camunda BPM Administrators");
+        camundaAdminGroup.setType(Groups.GROUP_TYPE_SYSTEM);
+        identityService.saveGroup(camundaAdminGroup);
+      }
+
+      // create ADMIN authorizations on all built-in resources
+      for (Resource resource : Resources.values()) {
+        if(authorizationService.createAuthorizationQuery().groupIdIn(Groups.CAMUNDA_ADMIN).resourceType(resource).resourceId(ANY).count() == 0) {
+          AuthorizationEntity userAdminAuth = new AuthorizationEntity(AUTH_TYPE_GRANT);
+          userAdminAuth.setGroupId(Groups.CAMUNDA_ADMIN);
+          userAdminAuth.setResource(resource);
+          userAdminAuth.setResourceId(ANY);
+          userAdminAuth.addPermission(ALL);
+          authorizationService.saveAuthorization(userAdminAuth);
+        }
+      }
+
+      processEngine.getIdentityService()
+      .createMembership("demo", Groups.CAMUNDA_ADMIN);
+    }
+  }
+
+
+
+  protected void scheduleInstanceStart() {
+    new Timer(true).schedule(new TimerTask() {
+      public void run() {
+
+        // start some process instances
+        int rand = new Random().nextInt(maxInstances);
+        for (int i = 0; i < rand; i++) {
+          processEngine.getRuntimeService().startProcessInstanceByKey("generatedFormsQuickstart");
+        }
+
+        // complete some process instances
+        rand = new Random().nextInt(maxInstances);
+        List<Task> tasks = processEngine.getTaskService().createTaskQuery()
+          .listPage(0, rand);
+        for (Task task : tasks) {
+          processEngine.getTaskService().complete(task.getId());
+        }
+
+        // reschedule
+        scheduleInstanceStart();
+      }
+    }, 1000);
+  }
+
+
+
+  public void setProcessEngine(ProcessEngine processEngine) {
+    this.processEngine = processEngine;
+  }
+
+  public ProcessEngine getProcessEngine() {
+    return processEngine;
+  }
+
+}

--- a/src/develop/resources/WEB-INF/applicationContext.xml
+++ b/src/develop/resources/WEB-INF/applicationContext.xml
@@ -1,0 +1,54 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:activiti="http://www.activiti.org/schema/spring/components"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+
+  <bean id="dataSource" class="org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy">
+    <property name="targetDataSource">
+      <bean class="org.apache.commons.dbcp.BasicDataSource">
+        <property name="driverClassName" value="org.h2.Driver" />
+        <property name="url" value="jdbc:h2:./target/camunda-h2-dbs/process-engine;MVCC=TRUE;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE" />
+        <property name="username" value="sa" />
+        <property name="password" value="" />
+      </bean>
+    </property>
+  </bean>
+
+  <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <property name="dataSource" ref="dataSource" />
+  </bean>
+
+  <bean id="processEngineConfiguration" class="org.camunda.bpm.engine.spring.SpringProcessEngineConfiguration">
+    <property name="processEngineName" value="default" />
+    <property name="dataSource" ref="dataSource" />
+    <property name="transactionManager" ref="transactionManager" />
+    <property name="databaseSchemaUpdate" value="true" />
+    <property name="jobExecutorActivate" value="false" />
+    <property name="deploymentResources" value="classpath*:bpmn/*.bpmn" />
+    <property name="authorizationEnabled" value="true" />
+    <property name="failedJobCommandFactory">
+      <bean class="org.camunda.bpm.engine.impl.jobexecutor.FoxFailedJobCommandFactory" />
+    </property>
+    <property name="idGenerator">
+      <bean class="org.camunda.bpm.engine.impl.persistence.StrongUuidGenerator" />
+    </property>
+  </bean>
+
+  <bean id="processEngine" class="org.camunda.bpm.engine.spring.ProcessEngineFactoryBean">
+    <property name="processEngineConfiguration" ref="processEngineConfiguration" />
+  </bean>
+
+  <bean id="repositoryService" factory-bean="processEngine" factory-method="getRepositoryService" />
+  <bean id="runtimeService" factory-bean="processEngine" factory-method="getRuntimeService" />
+  <bean id="taskService" factory-bean="processEngine" factory-method="getTaskService" />
+  <bean id="historyService" factory-bean="processEngine" factory-method="getHistoryService" />
+  <bean id="managementService" factory-bean="processEngine" factory-method="getManagementService" />
+
+  <!-- demo data generator -->
+  <bean class="org.camunda.bpm.extension.elasticsearch.cockpit.demodata.DemoDataGenerator">
+    <property name="processEngine" ref="processEngine"></property>
+  </bean>
+
+</beans>


### PR DESCRIPTION
I added a profile to pom.xml which allows to spawn a jetty instance with cockpit and the plugin. It also brings livereload for the javascript/html part of the plugin. Java classes must be recompiled. Maybe something like spring-reloaded can be used to archieve hotswapping during development.
