### PR TITLE
correct table name ACT_RU_EXECUTION

### DIFF
--- a/src/main/resources/org/camunda/cockpit/plugin/statistics/queries/runningProcessInstancesOByProcDefKey.xml
+++ b/src/main/resources/org/camunda/cockpit/plugin/statistics/queries/runningProcessInstancesOByProcDefKey.xml
@@ -16,7 +16,7 @@
       count(*) as COUNT,
       def.KEY_ as PROC_DEF_KEY
     FROM
-      act_ru_execution E
+      ACT_RU_EXECUTION E
         LEFT JOIN
           ACT_RE_PROCDEF def
         ON 


### PR DESCRIPTION
correct table name: act_ru_execution --> ACT_RU_EXECUTION
